### PR TITLE
FIX Incorrect DXL Fatal error logging

### DIFF
--- a/nsfodp/bundles/org.openntf.nsfodp.compiler/src/org/openntf/nsfodp/compiler/ODPCompiler.java
+++ b/nsfodp/bundles/org.openntf.nsfodp.compiler/src/org/openntf/nsfodp/compiler/ODPCompiler.java
@@ -75,6 +75,7 @@ import org.openntf.nsfodp.commons.odp.util.ODPUtil;
 import org.openntf.nsfodp.commons.xml.NSFODPDomUtil;
 import org.openntf.nsfodp.compiler.dxl.DxlImporterLog;
 import org.openntf.nsfodp.compiler.dxl.DxlImporterLog.DXLError;
+import org.openntf.nsfodp.compiler.dxl.DxlImporterLog.DXLFatalError;
 import org.openntf.nsfodp.compiler.util.CompilerUtil;
 import org.openntf.nsfodp.compiler.util.MultiPathResourceBundleSource;
 import org.osgi.framework.Bundle;
@@ -920,8 +921,8 @@ public class ODPCompiler extends AbstractCompilationEnvironment {
 						.collect(Collectors.joining(", ")); //$NON-NLS-1$
 					throw new Exception(MessageFormat.format("Exception importing {0}: {1}", name, msg));
 				} else if(log.getFatalErrors() != null && !log.getFatalErrors().isEmpty()) {
-					String msg = log.getErrors().stream()
-						.map(DXLError::getText)
+					String msg = log.getFatalErrors().stream()
+						.map(DXLFatalError::getText)
 						.collect(Collectors.joining(", ")); //$NON-NLS-1$
 					throw new Exception(MessageFormat.format("Exception importing {0}: {1}", name, msg));
 				}


### PR DESCRIPTION
Hi Jesse,

 I was getting an empty NPE when importing a lss file. It seems that the code was reading wrong log as the getErrors returned null. Based on the if I think it should be reading fatal errors. 

With this fix I got the correct error message - now I need to check what's wrong with the LSS file.
 